### PR TITLE
Fix/safari-workaround

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# Specifies intentionally untracked files to ignore when using Git
+# http://git-scm.com/docs/gitignore
+
+*~
+*.sw[mnpcod]
+.tmp
+*.tmp
+*.tmp.*
+*.sublime-project
+*.sublime-workspace
+.DS_Store
+Thumbs.db
+UserInterfaceState.xcuserstate
+$RECYCLE.BIN/
+
+*.log
+log.txt
+npm-debug.log*
+
+/.angular
+/.idea
+/.ionic
+/.sass-cache
+/.sourcemaps
+/.versions
+/.vscode
+/coverage
+/dist
+/node_modules
+/platforms
+/plugins
+/www

--- a/src/app/home/home.page.ts
+++ b/src/app/home/home.page.ts
@@ -14,7 +14,8 @@ export class HomePage {
   openModal() {
     this.modalCtrl.create({
       component: ModalComponent,
-      backdropDismiss: true
+      backdropDismiss: true,
+      cssClass: 'allow-fullscreen'
     }).then(r => r.present());
   }
 

--- a/src/global.scss
+++ b/src/global.scss
@@ -24,3 +24,9 @@
 @import "~@ionic/angular/css/text-alignment.css";
 @import "~@ionic/angular/css/text-transformation.css";
 @import "~@ionic/angular/css/flex-utils.css";
+
+
+ion-modal.allow-fullscreen:-webkit-full-screen-ancestor {
+    --height: 100vh;
+    --width: 100vw;
+}


### PR DESCRIPTION
Workaround for the safari fullscreen video issue.
- Add cssClass to config of `modalCtrl.create`. This will ensure that the css is only applied modals where it's needed
- Add a selector to update the css variables for `--height` and `--width` for modals with the custom cssClass and `:-webkit-full-screen-ancestor`.