### PR TITLE
workaround for submodals

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { ModalController } from '@ionic/angular';
 
 @Component({
   selector: 'app-root',
@@ -6,5 +7,27 @@ import { Component } from '@angular/core';
   styleUrls: ['app.component.scss'],
 })
 export class AppComponent {
-  constructor() {}
+  constructor(private modalCtrl: ModalController) {
+    // This listener is specfic to safari browsers and triggers when entering and exiting fullscreen
+    // Using this event to adjust the css of any open modals except
+    document.addEventListener('webkitfullscreenchange', async (e) => {
+      // boolean that defines the current fullscreen state
+      const isCurrentlyFullscreen = document['webkitIsFullScreen'];
+
+      // Get the top-most modal
+      const topModal = await this.modalCtrl.getTop();
+
+      //Create an array of modals that are NOT the top
+      const modals = Array.from(document.getElementsByTagName('ion-modal')).filter(x => x !== topModal);
+
+      //Loop through the modals and add/remove the css class (from global.scss) that forces 'z-index: auto'
+      modals.forEach(modal => {
+          if(isCurrentlyFullscreen) {
+            modal.classList.add('z-auto');
+          } else {
+            modal.classList.remove('z-auto');
+          }
+        });
+    });
+  }
 }

--- a/src/global.scss
+++ b/src/global.scss
@@ -30,3 +30,9 @@ ion-modal.allow-fullscreen:-webkit-full-screen-ancestor {
     --height: 100vh;
     --width: 100vw;
 }
+
+// Sets
+ion-modal.z-auto {
+    z-index: auto !important;
+}
+


### PR DESCRIPTION
A workaround solutuon for sub modals that relies on an event listener to force the proper z-index in webkit browsers. There seems to be another bug where the fullscreen ion-modal's z-index/position properties cannot be overridden